### PR TITLE
Add callbacks for onFocus and onBlur

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ input = new InputModule.Input
 	width: 500
 	height: 60
 	goButton: false # Set true here in order to use "Go" instead of "Return" as button (only works on real devices)
+	onFocus: () -> {} # Set a callback function to be called when your input is focused.
+	onBlur: () -> {} # Set a callback function to be called when your input is blurred.
 ```
 
 #### Styling your input

--- a/input.coffee
+++ b/input.coffee
@@ -32,6 +32,8 @@ class exports.Input extends Layer
 		options.virtualKeyboard ?= if Utils.isMobile() then false else true
 		options.type ?= "text"
 		options.goButton ?= false
+		options.onFocus ?= () -> {}
+		options.onBlur ?= () -> {}
 
 		super options
 
@@ -59,8 +61,10 @@ class exports.Input extends Layer
 			@input.addEventListener "focus", ->
 				exports.keyboardLayer.bringToFront()
 				exports.keyboardLayer.states.next()
+				options.onFocus()
 			@input.addEventListener "blur", ->
 				exports.keyboardLayer.states.switch "default"
+				options.onBlur()
 
 	updatePlaceholderColor: (color) ->
 		@placeholderColor = color


### PR DESCRIPTION
Maybe there is another way to do this but I personally ran in to situations where I wanted to move elements in my prototype based on whether the keyboard was visible or not.

Adding some simple callback options for the `focus` and `blur` events helped me to achieve that fairly easily. Open to a different approach if you have something in mind @ajimix 
