### PR TITLE
Replace deprecated state methods.

### DIFF
--- a/input.coffee
+++ b/input.coffee
@@ -74,9 +74,9 @@ class exports.Input extends Layer
 		if !Utils.isMobile() && options.virtualKeyboard is true
 			@input.addEventListener "focus", ->
 				exports.keyboardLayer.bringToFront()
-				exports.keyboardLayer.states.next()
+				exports.keyboardLayer.stateCycle()
 			@input.addEventListener "blur", ->
-				exports.keyboardLayer.states.switch "default"
+				exports.keyboardLayer.animate("default")
 
 	updatePlaceholderColor: (color) ->
 		@placeholderColor = color


### PR DESCRIPTION
Framer seems to have deprecated `layer.states.next()` and `layer.states. switch` some time ago. This PR replaces those methods with the new ones from the Framer API.