### PR TITLE
Add fontFamily, textColor, and fontWeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ input = new InputModule.Input
   placeholder: "Username" # Text visible before the user type
   placeholderColor: "#fff" # Color of the placeholder text
   text: "Some text" # Initial text in the input
+  textColor: "#000" # Color of the input text
   type: "text" # Use any of the available HTML input types. Take into account that on the computer the same keyboard image will appear regarding the type used.
   backgroundColor: "transparent" # e.g. "#ffffff" or "blue"
   fontSize: 30 # Size in px
+  fontFamily: "-apple-system" # Font family for placeholder and input text
+  fontWeight: "500" # Font weight for placeholder and input text
   lineHeight: 1 # Line height in em
   padding: 10 # Padding in px, multiple values are also supported via string, e.g. "10 5 16 2"
   autofocus: false # Change to true to enable autofocus

--- a/input.coffee
+++ b/input.coffee
@@ -98,6 +98,7 @@ class exports.Input extends Layer
 		options.autofocus ?= false
 		options.textColor ?= "#000"
 		options.fontFamily ?= "-apple-system"
+		options.fontWeight ?= "500"
 
 		super options
 
@@ -121,6 +122,7 @@ class exports.Input extends Layer
 		@input.style.padding = _inputStyle["padding"](@)
 		@input.style.fontFamily = options.fontFamily
 		@input.style.color = options.textColor
+		@input.style.fontWeight = options.fontWeight
 
 		@input.value = options.text
 		@input.type = options.type

--- a/input.coffee
+++ b/input.coffee
@@ -96,6 +96,8 @@ class exports.Input extends Layer
 		options.autoCapitalize ?= "on"
 		options.spellCheck ?= "on"
 		options.autofocus ?= false
+		options.textColor ?= "#000"
+		options.fontFamily ?= "-apple-system"
 
 		super options
 
@@ -117,6 +119,8 @@ class exports.Input extends Layer
 		@input.style.border = "none"
 		@input.style.backgroundColor = options.backgroundColor
 		@input.style.padding = _inputStyle["padding"](@)
+		@input.style.fontFamily = options.fontFamily
+		@input.style.color = options.textColor
 
 		@input.value = options.text
 		@input.type = options.type


### PR DESCRIPTION
First of all this module is awesome and thanks.

I needed to customize the font family and change the color of the input text when focused, and to do so added `fontFamily` and `textColor` options. (`textColor` maps to `color` in css, I didn't want to accidentally collide with Layer's `color` option).